### PR TITLE
Auto resend chunks

### DIFF
--- a/src/main/java/com/plotsquared/plothider/PlotHiderPlugin.java
+++ b/src/main/java/com/plotsquared/plothider/PlotHiderPlugin.java
@@ -53,6 +53,7 @@ public class PlotHiderPlugin extends JavaPlugin implements Listener {
     public void onEnable() {
         new PacketHandler(this);
         Bukkit.getPluginManager().registerEvents(this, this);
+        new PlotSquaredListener();
         GlobalFlagContainer.getInstance().addFlag(HideFlag.HIDE_FLAG_FALSE);
         try {
             loadCaptions();

--- a/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
+++ b/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
@@ -84,19 +84,39 @@ public class PlotSquaredListener implements Listener {
     }
 
     private void refreshPlot(Plot plot) {
+        int regionBottomCornerX = plot.getBottomAbs().getX();
+        int regionBottomCornerZ = plot.getBottomAbs().getZ();
+        int regionTopCornerX = plot.getTopAbs().getX();
+        int regionTopCornerZ = plot.getTopAbs().getZ();
+
         for (Plot connectedPlot : plot.getConnectedPlots()) {
             Location bottomCorner = connectedPlot.getBottomAbs();
             Location topCorner = connectedPlot.getTopAbs();
-            World world = (World) bottomCorner.getWorld().getPlatformWorld();
 
-            BlockVector2 fromChunk = bottomCorner.getChunkLocation();
-            BlockVector2 toChunk = topCorner.getChunkLocation();
+            if (bottomCorner.getX() < regionBottomCornerX) {
+                regionBottomCornerX = bottomCorner.getX();
+            }
+            if (bottomCorner.getZ() < regionBottomCornerZ) {
+                regionBottomCornerZ = bottomCorner.getZ();
+            }
+            if (topCorner.getX() > regionTopCornerX) {
+                regionTopCornerX = topCorner.getX();
+            }
+            if (topCorner.getZ() > regionTopCornerZ) {
+                regionTopCornerZ = topCorner.getZ();
+            }
+        }
 
-            for (int x = fromChunk.getX(); x <= toChunk.getX(); x++) {
-                for (int z = fromChunk.getZ(); z <= toChunk.getZ(); z++) {
-                    // Triggers a MapChunk packet, later handled by PlotHider's packet listener.
-                    world.refreshChunk(x, z);
-                }
+        World world = (World) plot.getBottomAbs().getWorld().getPlatformWorld();
+        int fromChunkX = regionBottomCornerX >> 4;
+        int fromChunkZ = regionBottomCornerZ >> 4;
+        int toChunkX = regionTopCornerX >> 4;
+        int toChunkZ = regionTopCornerZ >> 4;
+
+        for (int x = fromChunkX; x <= toChunkX; x++) {
+            for (int z = fromChunkZ; z <= toChunkZ; z++) {
+                // Triggers a MapChunk packet, later handled by PlotHider's packet listener.
+                world.refreshChunk(x, z);
             }
         }
     }

--- a/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
+++ b/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
@@ -23,6 +23,8 @@ import com.plotsquared.core.PlotAPI;
 import com.plotsquared.core.events.*;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.util.task.TaskManager;
+import com.plotsquared.core.util.task.TaskTime;
 import com.sk89q.worldedit.math.BlockVector2;
 import org.bukkit.World;
 import org.bukkit.event.Listener;
@@ -67,7 +69,8 @@ public class PlotSquaredListener implements Listener {
     public void onPlotFlagAddEvent(PlotFlagAddEvent event) {
         Plot plot = event.getPlot();
         if (event.getFlag() instanceof HideFlag) {
-            refreshPlot(plot);
+            // Waits a bit because the flag is added after the event call.
+            TaskManager.runTaskLater(() -> refreshPlot(plot), TaskTime.ticks(1));
         }
     }
 
@@ -75,7 +78,8 @@ public class PlotSquaredListener implements Listener {
     public void onPlotFlagRemoveEvent(PlotFlagRemoveEvent event) {
         Plot plot = event.getPlot();
         if (event.getFlag() instanceof HideFlag) {
-            refreshPlot(plot);
+            // Waits a bit because the flag is removed after the event call.
+            TaskManager.runTaskLater(() -> refreshPlot(plot), TaskTime.ticks(1));
         }
     }
 

--- a/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
+++ b/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
@@ -1,0 +1,93 @@
+/*
+ * PlotHider, an addon to hide plots for the PlotSquared plugin for Minecraft.
+ * Copyright (C) IntellectualSites <https://intellectualsites.com>
+ * Copyright (C) IntellectualSites team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+package com.plotsquared.plothider;
+
+import com.google.common.eventbus.Subscribe;
+import com.plotsquared.core.PlotAPI;
+import com.plotsquared.core.events.*;
+import com.plotsquared.core.location.Location;
+import com.plotsquared.core.plot.Plot;
+import com.sk89q.worldedit.math.BlockVector2;
+import org.bukkit.World;
+import org.bukkit.event.Listener;
+
+public class PlotSquaredListener implements Listener {
+
+    public static final PlotAPI PLOT_API;
+
+    static {
+        PLOT_API = new PlotAPI();
+    }
+
+    public PlotSquaredListener() {
+        PLOT_API.registerListener(this);
+    }
+
+    @Subscribe
+    public void onPlayerPlotDeniedEvent(PlayerPlotDeniedEvent event) {
+        Plot plot = event.getPlot();
+        if (plot.getFlag(HideFlag.class)) {
+            refreshPlot(event.getPlot());
+        }
+    }
+
+    @Subscribe
+    public void onPlayerPlotTrusted(PlayerPlotTrustedEvent event) {
+        Plot plot = event.getPlot();
+        if (plot.getFlag(HideFlag.class)) {
+            refreshPlot(plot);
+        }
+    }
+
+    @Subscribe
+    public void onPlayerPlotHelperEvent(PlayerPlotHelperEvent event) {
+        Plot plot = event.getPlot();
+        if (plot.getFlag(HideFlag.class)) {
+            refreshPlot(plot);
+        }
+    }
+
+    @Subscribe
+    public void onPlotFlagAddEvent(PlotFlagAddEvent event) {
+        refreshPlot(event.getPlot());
+    }
+
+    @Subscribe
+    public void onPlotFlagRemoveEvent(PlotFlagRemoveEvent event) {
+        refreshPlot(event.getPlot());
+    }
+
+    private void refreshPlot(Plot plot) {
+        for (Plot connectedPlot : plot.getConnectedPlots()) {
+            Location bottomCorner = connectedPlot.getBottomAbs();
+            Location topCorner = connectedPlot.getTopAbs();
+            World world = (World) bottomCorner.getWorld().getPlatformWorld();
+
+            BlockVector2 fromChunk = bottomCorner.getChunkLocation();
+            BlockVector2 toChunk = topCorner.getChunkLocation();
+
+            for (int x = fromChunk.getX(); x <= toChunk.getX(); x++) {
+                for (int z = fromChunk.getZ(); z <= toChunk.getZ(); z++) {
+                    world.refreshChunk(x, z);
+                }
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
+++ b/src/main/java/com/plotsquared/plothider/PlotSquaredListener.java
@@ -65,12 +65,18 @@ public class PlotSquaredListener implements Listener {
 
     @Subscribe
     public void onPlotFlagAddEvent(PlotFlagAddEvent event) {
-        refreshPlot(event.getPlot());
+        Plot plot = event.getPlot();
+        if (event.getFlag() instanceof HideFlag) {
+            refreshPlot(plot);
+        }
     }
 
     @Subscribe
     public void onPlotFlagRemoveEvent(PlotFlagRemoveEvent event) {
-        refreshPlot(event.getPlot());
+        Plot plot = event.getPlot();
+        if (event.getFlag() instanceof HideFlag) {
+            refreshPlot(plot);
+        }
     }
 
     private void refreshPlot(Plot plot) {
@@ -84,6 +90,7 @@ public class PlotSquaredListener implements Listener {
 
             for (int x = fromChunk.getX(); x <= toChunk.getX(); x++) {
                 for (int z = fromChunk.getZ(); z <= toChunk.getZ(); z++) {
+                    // Triggers a MapChunk packet, later handled by PlotHider's packet listener.
                     world.refreshChunk(x, z);
                 }
             }


### PR DESCRIPTION
## Description
<!-- Please describe what this pull request does. -->
This pull request aims to automate a bit hidden chunks update. All visibility changes caused by plot squared actions are now handled to resend the chunks to nearby players (i.e. adding/trusting/banning players, setting ``hide`` flag value) and the triggers the ProtocolLib logic.

_This is made possible by a recent Paper fix: https://github.com/PaperMC/Paper/commit/e8c2c3bfda97143e33dbd35bd9dee528bb51d93c_

## Submitter Checklist
<!-- Make sure you have completed the following steps (put an "X" between of brackets): -->
- [x] Make sure you are opening from a topic branch (**/feature/fix/docs/ branch** (right side)) and not your main branch.
- [x] Ensure that the pull request title represents the desired changelog entry.
- [x] New public fields and methods are annotated with `@since TODO`.
- [x] I read and followed the [contribution guidelines](https://github.com/IntellectualSites/.github/blob/main/CONTRIBUTING.md).
